### PR TITLE
Use openstreetmap on map page

### DIFF
--- a/files/common/www/admin/contact.cgi
+++ b/files/common/www/admin/contact.cgi
@@ -50,9 +50,9 @@ cat<<EOF
 <td><button onclick="ajax_geoloc()" type="button" title="$(lang text-geoloc01)">$(lang text-geoloc00)</button></td>
 </tr>
 
-<tr title="GPS-Position,L&auml;ngengrad (z.B.:13.72053812812492">
+<tr title="GPS-Position,L&auml;ngengrad (z.B.:13.72053812812492)">
 <th>GPS Longitude:</th>
-<td><input id="geoloc_lng" name="form_gps_longitude" size="20" type="text" value="$lon">(z.B.:13.720</td>
+<td><input id="geoloc_lng" name="form_gps_longitude" size="20" type="text" value="$lon">(z.B.:13.72053812812492)</td>
 <td></td>
 </tr>
 
@@ -75,10 +75,21 @@ cat<<EOF
 Diese Angaben sind auf der Seite <a href="/contact.cgi">Kontakt</a>
 f&uuml;r andere sichtbar.</p>
 <fieldset class="bubble">
-<legend>Google Maps</legend>
-<img id="geoloc_map" border="0" src="https://freifunk.it-service-merkelt.de/staticmap.php?center=$lat,$lon&zoom=15&markers=$lat,$lon,ol-marker-blue">
+<legend>Openstreetmap</legend>
+<div id="nodeMap"></div>
+<style>
+@import"https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.css";
+#nodeMap{height:300px;width:600px;}
+</style>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.js"></script>
+<script>
+var map = L.map('nodeMap').setView([$lat, $lon], 18);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+}).addTo(map);
+L.marker([$lat, $lon]).addTo(map).bindPopup('$COMMUNITY [$_ddmesh_node]').openPopup();
+</script>
 </fieldset>
-
 EOF
 }
 

--- a/files/common/www/admin/contact.cgi
+++ b/files/common/www/admin/contact.cgi
@@ -14,6 +14,8 @@ tmp_name=$(uhttpd -d "$(uci get ddmesh.contact.name)")
 tmp_email=$(uhttpd -d "$(uci get ddmesh.contact.email)")
 tmp_location=$(uhttpd -d "$(uci get ddmesh.contact.location)")
 tmp_note=$(uhttpd -d "$(uci get ddmesh.contact.note)")
+lat=$(uci get ddmesh.gps.latitude)
+lon=$(uci get ddmesh.gps.longitude)
 
 cat<<EOF
 <form action="contact.cgi" method="POST">
@@ -44,13 +46,13 @@ cat<<EOF
 
 <tr title="GPS-Position,Breitengrad (z.B.: 51.05812205978327)">
 <th>GPS Latitude:</th>
-<td><input id="geoloc_lat" name="form_gps_latitude" size="20" type="text" value="$(uci get ddmesh.gps.latitude)">(z.B.: 51.05812205978327)</td>
+<td><input id="geoloc_lat" name="form_gps_latitude" size="20" type="text" value="$lat">(z.B.: 51.05812205978327)</td>
 <td><button onclick="ajax_geoloc()" type="button" title="$(lang text-geoloc01)">$(lang text-geoloc00)</button></td>
 </tr>
 
 <tr title="GPS-Position,L&auml;ngengrad (z.B.:13.72053812812492">
 <th>GPS Longitude:</th>
-<td><input id="geoloc_lng" name="form_gps_longitude" size="20" type="text" value="$(uci get ddmesh.gps.longitude)">(z.B.:13.720</td>
+<td><input id="geoloc_lng" name="form_gps_longitude" size="20" type="text" value="$lon">(z.B.:13.720</td>
 <td></td>
 </tr>
 
@@ -74,7 +76,7 @@ Diese Angaben sind auf der Seite <a href="/contact.cgi">Kontakt</a>
 f&uuml;r andere sichtbar.</p>
 <fieldset class="bubble">
 <legend>Google Maps</legend>
-<img id="geoloc_map" border="0" src="http://maps.googleapis.com/maps/api/staticmap?zoom=15&size=600x300&maptype=roadmap&markers=color:green%7Clabel:R%7C$(uci get ddmesh.gps.latitude),$(uci get ddmesh.gps.longitude)&sensor=false">
+<img id="geoloc_map" border="0" src="https://freifunk.it-service-merkelt.de/staticmap.php?center=$lat,$lon&zoom=15&markers=$lat,$lon,ol-marker-blue">
 </fieldset>
 
 EOF

--- a/files/common/www/map.cgi
+++ b/files/common/www/map.cgi
@@ -10,7 +10,19 @@ cat <<EOF
 <br>
 <fieldset class="bubble">
 <legend>Openstreetmap</legend>
-<img border="0" alt="standort" src="https://freifunk.it-service-merkelt.de/staticmap.php?center=$lat,$lon&zoom=15&markers=$lat,$lon,ol-marker-blue">
+<div id="nodeMap"></div>
+<style>
+@import"https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.css";
+#nodeMap{height:300px;width:600px;}
+</style>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.js"></script>
+<script>
+var map = L.map('nodeMap').setView([$lat, $lon], 18);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+}).addTo(map);
+L.marker([$lat, $lon]).addTo(map).bindPopup('$COMMUNITY [$_ddmesh_node]').openPopup();
+</script>
 </fieldset>
 EOF
 

--- a/files/common/www/map.cgi
+++ b/files/common/www/map.cgi
@@ -2,15 +2,16 @@
 
 export TITLE="Infos: Karte"
 . /usr/lib/www/page-pre.sh
+export lat=$(uci get ddmesh.gps.latitude)
+export lon=$(uci get ddmesh.gps.longitude)
 
 cat <<EOF
 <h2>$TITLE</h2>
 <br>
 <fieldset class="bubble">
-<legend>Google Maps</legend>
-<img border="0" alt="standort" src="http://maps.googleapis.com/maps/api/staticmap?zoom=15&size=600x300&maptype=roadmap&markers=color:blue%7Clabel:R%7C$(uci get ddmesh.gps.latitude),$(uci get ddmesh.gps.longitude)&sensor=false">
+<legend>Openstreetmap</legend>
+<img border="0" alt="standort" src="https://freifunk.it-service-merkelt.de/staticmap.php?center=$lat,$lon&zoom=15&markers=$lat,$lon,ol-marker-blue">
 </fieldset>
 EOF
-
 
 . /usr/lib/www/page-post.sh


### PR DESCRIPTION
Implemetation of openstreetmap on map page

This Implementation useses the staticmap script from [dfacts](https://github.com/dfacts/staticmaplite).
The script is installed on my server, but could also be installed on a server of Freifunk Dresden.
