### PR TITLE
Umbenennung "Infos | System" in "Allgemein" in Navigation.

### DIFF
--- a/files/common/www/admin/21-system
+++ b/files/common/www/admin/21-system
@@ -1,1 +1,1 @@
-<tr><td><div class="plugin"><a class="plugin" href="index.cgi">System</a></div></td></tr>
+<tr><td><div class="plugin"><a class="plugin" href="index.cgi">Allgemein</a></div></td></tr>


### PR DESCRIPTION
Die Bezeichnung "System" doppelt sich in der Navigationsleiste, was immer wieder zu Verwirrungen führt. Vorschlag: Umbenennung in "Allgemein", wie es auch schon in der Kopfzeile der Seite selbst auch steht ("Verwaltung > Allgemein").